### PR TITLE
Fix/query params conserved

### DIFF
--- a/cmd/handlers/auth.go
+++ b/cmd/handlers/auth.go
@@ -50,7 +50,13 @@ func (h *AuthHandler) PostLogin(ctx *gin.Context) {
 	}
 	user := generateUserResponse(request)
 	ticket := h.authService.PostLogin(user)
-	ctx.Redirect(http.StatusFound, generatePath(request.Service, ticket))
+
+	redirectURL, err := h.authService.GeneratePath(request.Service, ticket)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.Redirect(http.StatusFound, redirectURL)
 }
 
 func generateUserResponse(request models.PostLoginRequest) models.UserResponse {
@@ -70,10 +76,6 @@ func generateUserResponse(request models.PostLoginRequest) models.UserResponse {
 		OUID:        request.UID,
 		Email:       email,
 	}
-}
-
-func generatePath(service string, ticket string) string {
-	return fmt.Sprintf("%s?ticket=%s", service, ticket)
 }
 
 func (h *AuthHandler) ServiceValidation(ctx *gin.Context) {

--- a/cmd/handlers/auth.go
+++ b/cmd/handlers/auth.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/wire"
@@ -33,6 +34,11 @@ func (h *AuthHandler) GetLogin(ctx *gin.Context) {
 	var request models.GetLoginRequest
 
 	if err := ctx.ShouldBind(&request); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := url.Parse(request.Service); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/services/auth.go
+++ b/internal/services/auth.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/google/uuid"
 	"github.com/google/wire"
@@ -20,6 +21,7 @@ type AppSecret struct {
 type IAuthService interface {
 	PostLogin(user models.UserResponse) string
 	ServiceValidation(models.ServiceValidateRequest) (models.UserResponse, error)
+	GeneratePath(service string, ticket string) (result string, err error)
 }
 
 type AuthService struct {
@@ -53,4 +55,20 @@ func (h *AuthService) ServiceValidation(request models.ServiceValidateRequest) (
 		return models.UserResponse{}, fmt.Errorf("ticket not found")
 	}
 	return user, nil
+}
+
+func (h *AuthService) GeneratePath(service string, ticket string) (result string, err error) {
+	var u *url.URL
+
+	if u, err = url.Parse(service); err != nil {
+		return
+	}
+
+	values := u.Query()
+	values.Add("ticket", ticket)
+
+	u.RawQuery = values.Encode()
+	result = u.String()
+
+	return
 }

--- a/internal/services/auth.go
+++ b/internal/services/auth.go
@@ -57,18 +57,17 @@ func (h *AuthService) ServiceValidation(request models.ServiceValidateRequest) (
 	return user, nil
 }
 
-func (h *AuthService) GeneratePath(service string, ticket string) (result string, err error) {
-	var u *url.URL
+func (h *AuthService) GeneratePath(service string, ticket string) (string, error) {
+	u, err := url.Parse(service)
 
-	if u, err = url.Parse(service); err != nil {
-		return
+	if err != nil {
+		return "", err
 	}
 
 	values := u.Query()
 	values.Add("ticket", ticket)
 
 	u.RawQuery = values.Encode()
-	result = u.String()
 
-	return
+	return u.String(), nil
 }

--- a/internal/services/mocks/auth.go
+++ b/internal/services/mocks/auth.go
@@ -34,6 +34,21 @@ func (m *MockIAuthService) EXPECT() *MockIAuthServiceMockRecorder {
 	return m.recorder
 }
 
+// GeneratePath mocks base method.
+func (m *MockIAuthService) GeneratePath(service, ticket string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GeneratePath", service, ticket)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GeneratePath indicates an expected call of GeneratePath.
+func (mr *MockIAuthServiceMockRecorder) GeneratePath(service, ticket interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GeneratePath", reflect.TypeOf((*MockIAuthService)(nil).GeneratePath), service, ticket)
+}
+
 // PostLogin mocks base method.
 func (m *MockIAuthService) PostLogin(user models.UserResponse) string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
due to https://github.com/remove158/chula-sso/issues/1#issue-1444244727

> When a redirect URL with query params is passed to the SSO service, a ticket must be concatenated to the redirect URL in the way that the validity of query params is conserved.
## Before
```go
func generatePath(service string, ticket string) string {
	return fmt.Sprintf("%s?ticket=%s", service, ticket)
}
```
## After
```go
func (h *AuthService) GeneratePath(service string, ticket string) (string, error) {
	u, err := url.Parse(service)

	if err != nil {
		return "", err
	}

	values := u.Query()
	values.Add("ticket", ticket)

	u.RawQuery = values.Encode()

	return u.String(), nil
}
```